### PR TITLE
Add gitpod config

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,3 @@
+tasks:
+  - init: ./bin/build.sh
+

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Mergify Status][mergify-status]][mergify]
 [![Synk Status](https://snyk.io/test/github/proinsias/proinsias.github.io/badge.svg?targetFile=Gemfile.lock)](https://snyk.io/test/github/proinsias/proinsias.github.io?targetFile=Gemfile.lock)
 [![License](https://img.shields.io/github/license/proinsias/proinsias.github.io.svg)](https://github.com/proinsias/proinsias.github.io/blob/master/LICENSE)
+[![Gitpod Ready-to-Code](https://img.shields.io/badge/Gitpod-Ready--to--Code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/proinsias/proinsias.github.io) 
 
 The source code for the personal website of Francis T. O'Donovan,
 hosted by [GitHub Pages](http://pages.github.com).


### PR DESCRIPTION
This commit adds support for Gitpod.io, a free automated
dev environment that makes contributing and generally working on GitHub
projects much easier. It allows anyone to start a ready-to-code dev
environment for any branch, issue and pull request with a single click.