### PR TITLE
fix: exclude LinkedIn from link checker (closes #515)

### DIFF
--- a/lychee.toml
+++ b/lychee.toml
@@ -3,7 +3,7 @@
 accept = ["100..=103", "200..=299", "403"]
 
 # Exclude URLs and mail addresses from checking (supports regex).
-# exclude = ['^https://www.linkedin.com']
+exclude = ['^https://www.linkedin.com']
 
 exclude_path = [
     "assets/js/**/*.js",


### PR DESCRIPTION
Fixes two link checker errors:

- **LinkedIn 999**: LinkedIn blocks automated crawlers with 999 status. Uncomment existing exclusion in `lychee.toml`.
- **Bitbucket 404**: Stale link from old deployment; rebuilding the site removes it automatically.

Closes #515

Generated with [Claude Code](https://claude.ai/code)